### PR TITLE
Prevent panic on failure to Create

### DIFF
--- a/openfile.go
+++ b/openfile.go
@@ -61,5 +61,8 @@ func OpenFile(fsys FS, name string, flag int, perm FileMode) (File, error) {
 // be used for I/O; the associated file descriptor has mode O_RDWR.
 func Create(fsys FS, name string) (WriteFile, error) {
 	file, err := OpenFile(fsys, name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return nil, err
+	}
 	return file.(WriteFile), err
 }


### PR DESCRIPTION
Prevents a panic when OpenFile returns nil due to an error.

```
panic: interface conversion: interface is nil, not wrfs.WriteFile

goroutine 1 [running]:
github.com/relab/wrfs.Create(...)
	/Users/rpatterson/.virtualgo/pilikino/pkg/mod/github.com/relab/wrfs@v0.0.0-20210628111300-b51570396aec/openfile.go:64
main.init.1.func1.1(0x13a0c2d, 0x1, 0x1444be0, 0xc000098c30, 0x0, 0x0, 0x0, 0x0)
	...
```